### PR TITLE
[Fix] Enable non valid URI file path to not resulting 404 on github permalink

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export function activate(context: vscode.ExtensionContext) {
 
       repository.getCommit('HEAD').then((commit) => {
         const treeOrBlob = filePath.length === 0 ? 'tree' : 'blob';
-        const url = `${httpsUrl}/${treeOrBlob}/${commit.hash}/${filePath}`;
+        const url = `${httpsUrl}/${treeOrBlob}/${commit.hash}/${encodeURI(filePath)}`;
         vscode.env.clipboard.writeText(url);
         vscode.window.showInformationMessage(`"${url}" copied`, {
           modal: false,


### PR DESCRIPTION
# Summary
File path like this `https://github.com/{username}/{repository}/blob/{commitHash}/src/app/(main)/(buyer)/categories/[id]/page.tsx#L19` are not valid github permalink because of `[id]` is not a valid URI. This PR will normalize this type of character to encoded URI.

# Solution
Use `encodeURI` to encode file path
![image](https://github.com/user-attachments/assets/26ce1a42-9730-407e-9c52-0fb0316c5212)